### PR TITLE
Create .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+WEBHOOK_URL="https://discord.com/api/webhooks/xxx"


### PR DESCRIPTION
A good practice when using .env files is to provide an example file with some defaults and placeholders.  Then people can copy the example file to .env and edit the info that they care about.
ref #1 